### PR TITLE
fix: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
     "jssha": "3.2.0",
     "tweetnacl": "1.0.3"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22",
+  "homepage": "https://github.com/ton-org/ton-crypto#readme",
+  "bugs": {
+    "url": "https://github.com/ton-org/ton-crypto/issues"
+  }
 }


### PR DESCRIPTION
Adds standard npm support metadata to `package.json`:

- `homepage` points to the repository README
- `bugs.url` points to the GitHub issue tracker

Current `npm view @ton/crypto@3.3.0 ... homepage bugs` omits those fields even though the public repository and issue tracker exist.

Verification:

```sh
node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ton crypto package json valid')"
npm pack --dry-run --json --ignore-scripts
```

Metadata-only change; no runtime behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package metadata by adding project homepage and bug reporting information. Users can now easily access the project website and the issue tracker for reporting problems and getting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->